### PR TITLE
Implement Racial Innate Spellcasting and Abilities (Issue #51)

### DIFF
--- a/DMContent/Races/dragonborn.yml
+++ b/DMContent/Races/dragonborn.yml
@@ -9,10 +9,98 @@ ability_scores:
       - [1, 1, 1]   # Or spread across three abilities
 size: Medium
 speed: 30
+
+# Display-only trait names (for character sheet)
 traits:
   - Draconic Ancestry
   - Breath Weapon
   - Damage Resistance
+
 languages:
   - Common
   - Draconic
+
+# Player choices during character creation
+player_choices:
+  - id: draconic_ancestry
+    title: Draconic Ancestry
+    type: CUSTOM
+    choose: 1
+    options:
+      - Black (Acid, 5x30 ft. line, DEX save)
+      - Blue (Lightning, 5x30 ft. line, DEX save)
+      - Brass (Fire, 5x30 ft. line, DEX save)
+      - Bronze (Lightning, 5x30 ft. line, DEX save)
+      - Copper (Acid, 5x30 ft. line, DEX save)
+      - Gold (Fire, 15 ft. cone, DEX save)
+      - Green (Poison, 15 ft. cone, CON save)
+      - Red (Fire, 15 ft. cone, DEX save)
+      - Silver (Cold, 15 ft. cone, CON save)
+      - White (Cold, 15 ft. cone, CON save)
+
+# Mechanical trait implementations
+# Damage resistance: Linked to draconic ancestry choice
+damage_resistance:
+  type: linked
+  source_choice: draconic_ancestry
+  mapping:
+    "Black (Acid, 5x30 ft. line, DEX save)": acid
+    "Blue (Lightning, 5x30 ft. line, DEX save)": lightning
+    "Brass (Fire, 5x30 ft. line, DEX save)": fire
+    "Bronze (Lightning, 5x30 ft. line, DEX save)": lightning
+    "Copper (Acid, 5x30 ft. line, DEX save)": acid
+    "Gold (Fire, 15 ft. cone, DEX save)": fire
+    "Green (Poison, 15 ft. cone, CON save)": poison
+    "Red (Fire, 15 ft. cone, DEX save)": fire
+    "Silver (Cold, 15 ft. cone, CON save)": cold
+    "White (Cold, 15 ft. cone, CON save)": cold
+
+# Breath Weapon: Limited-use racial resource
+racial_resources:
+  - id: breath_weapon
+    name: Breath Weapon
+    uses_proficiency_bonus: true  # Uses = proficiency bonus
+    recovery: long_rest
+    linked_to_choice: draconic_ancestry
+    description: "You can use your action to exhale destructive energy."
+    damage_mapping:
+      "Black (Acid, 5x30 ft. line, DEX save)":
+        damage_type: acid
+        area: "5 by 30 ft. line"
+        save: dexterity
+      "Blue (Lightning, 5x30 ft. line, DEX save)":
+        damage_type: lightning
+        area: "5 by 30 ft. line"
+        save: dexterity
+      "Brass (Fire, 5x30 ft. line, DEX save)":
+        damage_type: fire
+        area: "5 by 30 ft. line"
+        save: dexterity
+      "Bronze (Lightning, 5x30 ft. line, DEX save)":
+        damage_type: lightning
+        area: "5 by 30 ft. line"
+        save: dexterity
+      "Copper (Acid, 5x30 ft. line, DEX save)":
+        damage_type: acid
+        area: "5 by 30 ft. line"
+        save: dexterity
+      "Gold (Fire, 15 ft. cone, DEX save)":
+        damage_type: fire
+        area: "15 ft. cone"
+        save: dexterity
+      "Green (Poison, 15 ft. cone, CON save)":
+        damage_type: poison
+        area: "15 ft. cone"
+        save: constitution
+      "Red (Fire, 15 ft. cone, DEX save)":
+        damage_type: fire
+        area: "15 ft. cone"
+        save: dexterity
+      "Silver (Cold, 15 ft. cone, CON save)":
+        damage_type: cold
+        area: "15 ft. cone"
+        save: constitution
+      "White (Cold, 15 ft. cone, CON save)":
+        damage_type: cold
+        area: "15 ft. cone"
+        save: constitution

--- a/DMContent/Races/dwarf.yml
+++ b/DMContent/Races/dwarf.yml
@@ -7,15 +7,48 @@ ability_scores:
     Constitution: 2
 size: Medium
 speed: 25
+
+# Display-only trait names
 traits:
   - Darkvision
   - Dwarven Resilience
   - Dwarven Combat Training
   - Tool Proficiency
   - Stonecunning
+
 languages:
   - Common
   - Dwarvish
+
+# Player choices during character creation
+player_choices:
+  - id: tool_proficiency
+    title: Tool Proficiency
+    type: TOOL
+    choose: 1
+    options:
+      - smiths_tools
+      - brewers_supplies
+      - masons_tools
+
+# Mechanical trait implementations
+darkvision: 60  # 60 ft. darkvision range
+
+# Dwarven Resilience: Advantage on saving throws against poison + resistance
+damage_resistances:
+  - poison
+conditional_advantages:
+  - type: saving_throw
+    condition: poison
+    description: "You have advantage on saving throws against poison."
+
+# Dwarven Combat Training: Weapon proficiencies
+weapon_proficiencies:
+  - battleaxe
+  - handaxe
+  - light_hammer
+  - warhammer
+
 subraces:
   hill_dwarf:
     name: Hill Dwarf
@@ -25,6 +58,9 @@ subraces:
         Wisdom: 1
     traits:
       - Dwarven Toughness
+    # Dwarven Toughness: +1 HP per level (same as Tough feat)
+    toughness: true
+
   mountain_dwarf:
     name: Mountain Dwarf
     description: As a mountain dwarf, you're strong and hardy, accustomed to a difficult life in rugged terrain.
@@ -33,6 +69,11 @@ subraces:
         Strength: 2
     traits:
       - Dwarven Armor Training
+    # Dwarven Armor Training: Armor proficiencies
+    armor_proficiencies:
+      - light_armor
+      - medium_armor
+
   duergar:
     name: Duergar (Gray Dwarf)
     description: Duergar are gray-skinned dwarves that dwell in the Underdark, known for their cruelty and dark magic.
@@ -44,3 +85,36 @@ subraces:
       - Duergar Resilience
       - Duergar Magic
       - Sunlight Sensitivity
+    # Superior Darkvision: Extended range
+    darkvision: 120
+    # Duergar Resilience: Advantage on saves vs illusions, charms, paralysis + poison resistance
+    damage_resistances:
+      - poison
+    conditional_advantages:
+      - type: saving_throw
+        condition: illusion
+        description: "You have advantage on saving throws against illusions."
+      - type: saving_throw
+        condition: charmed
+        description: "You have advantage on saving throws against being charmed."
+      - type: saving_throw
+        condition: paralyzed
+        description: "You have advantage on saving throws against being paralyzed."
+    # Duergar Magic: Innate spellcasting
+    innate_spells:
+      - spell_id: enlarge_reduce
+        level_requirement: 3
+        spell_level: 2
+        uses: 1
+        recovery: long_rest
+        casting_ability: intelligence
+        description: "You can cast Enlarge/Reduce on yourself once per long rest, starting at 3rd level."
+      - spell_id: invisibility
+        level_requirement: 5
+        spell_level: 2
+        uses: 1
+        recovery: long_rest
+        casting_ability: intelligence
+        description: "You can cast Invisibility on yourself once per long rest, starting at 5th level."
+    # Sunlight Sensitivity: Disadvantage on attack rolls and Perception checks in sunlight
+    # (This would need special handling in combat system)

--- a/DMContent/Races/elf.yml
+++ b/DMContent/Races/elf.yml
@@ -7,14 +7,40 @@ ability_scores:
     Dexterity: 2
 size: Medium
 speed: 30
+
+# Display-only trait names
 traits:
-- Darkvision
-- Fey Ancestry
-- Trance
-- Keen Senses
+  - Darkvision
+  - Fey Ancestry
+  - Trance
+  - Keen Senses
+
 languages:
- - Common
- - Elvish
+  - Common
+  - Elvish
+
+# Mechanical trait implementations
+darkvision: 60  # 60 ft. darkvision range
+
+# Keen Senses: Proficiency in Perception skill
+skill_proficiencies:
+  - perception
+
+# Fey Ancestry: Advantage on saves vs charmed, immune to magical sleep
+conditional_advantages:
+  - type: saving_throw
+    condition: charmed
+    description: "You have advantage on saving throws against being charmed."
+condition_immunities:
+  - type: sleep
+    magical_only: true
+    description: "Magic can't put you to sleep."
+
+# Trance: Only need 4 hours for long rest (Issue #63)
+rest_requirements:
+  long_rest_hours: 4
+  description: "Elves don't need to sleep. Instead, they meditate deeply for 4 hours a day."
+
 subraces:
   dark_elf:
     name: Dark Elf
@@ -26,37 +52,116 @@ subraces:
       - Sunlight Sensitivity
       - Drow Magic
       - Drow Weapon Training
+    # Superior Darkvision
+    darkvision: 120
+    # Drow Magic: Innate spellcasting
+    innate_spells:
+      - spell_id: dancing_lights
+        level_requirement: 1
+        is_cantrip: true
+        casting_ability: charisma
+      - spell_id: faerie_fire
+        level_requirement: 3
+        spell_level: 1
+        uses: 1
+        recovery: long_rest
+        casting_ability: charisma
+      - spell_id: darkness
+        level_requirement: 5
+        spell_level: 2
+        uses: 1
+        recovery: long_rest
+        casting_ability: charisma
+    # Drow Weapon Training
+    weapon_proficiencies:
+      - rapier
+      - shortsword
+      - hand_crossbow
+    # Sunlight Sensitivity: Disadvantage on attack rolls and Perception in sunlight (Issue #63)
+    sunlight_sensitivity: true
+
   high_elf:
     name: High Elf
     ability_scores:
       fixed:
         Intelligence: 1
     traits:
-    - 'Cantrip: choose from Wizard list'
-    - Elf Weapon Training
+      - Cantrip
+      - Elf Weapon Training
+      - Extra Language
+    # Cantrip choice from Wizard list
     player_choices:
+      - id: wizard_cantrip
+        title: Wizard Cantrip
+        type: SPELL
+        choose: 1
+        spell_list: wizard
+        spell_level: 0  # 0 = cantrips only
       - id: subrace_languages
         title: Extra Language
         type: LANGUAGE
         choose: 1
         options: []
+    # Elf Weapon Training
+    weapon_proficiencies:
+      - longsword
+      - shortsword
+      - shortbow
+      - longbow
+
   wood_elf:
     name: Wood Elf
     ability_scores:
       fixed:
         Wisdom: 1
     traits:
-    - Elf Weapon Training
-    - Fleet of Foot
-    - Mask of the Wild
+      - Elf Weapon Training
+      - Fleet of Foot
+      - Mask of the Wild
+    # Fleet of Foot
+    speed: 35  # Overrides base 30
+    # Elf Weapon Training
+    weapon_proficiencies:
+      - longsword
+      - shortsword
+      - shortbow
+      - longbow
+    # Mask of the Wild: Can hide when lightly obscured by natural phenomena (Issue #63)
+    special_hide_rules:
+      - type: natural_obscurement
+        conditions: [foliage, heavy_rain, falling_snow, mist, natural_phenomena]
+        description: "You can attempt to hide even when you are only lightly obscured by foliage, heavy rain, falling snow, mist, and other natural phenomena."
+
   pallid_elf:
     name: Pallid Elf
     ability_scores:
       fixed:
         Wisdom: 1
     traits:
-    - Incisive Sense
-    - Blessing of the Moonweaver
+      - Incisive Sense
+      - Blessing of the Moonweaver
+    # Incisive Sense: Advantage on Investigation and Insight checks
+    # (Would need special handling in skill check system)
+    # Blessing of the Moonweaver: Innate spellcasting
+    innate_spells:
+      - spell_id: light
+        level_requirement: 1
+        is_cantrip: true
+        casting_ability: wisdom
+      - spell_id: sleep
+        level_requirement: 3
+        spell_level: 1
+        uses: 1
+        recovery: long_rest
+        casting_ability: wisdom
+      - spell_id: invisibility
+        level_requirement: 5
+        spell_level: 2
+        uses: 1
+        recovery: long_rest
+        casting_ability: wisdom
+        description: "You can cast this spell on yourself only."
+
   astral_elf:
     name: Astral Elf
     ability_scores:
@@ -71,8 +176,23 @@ subraces:
       - Starlight Step
       - Astral Trance
     player_choices:
+      - id: astral_fire_cantrip
+        title: "Astral Fire Cantrip"
+        type: SPELL
+        choose: 1
+        options: [dancing_lights, light, sacred_flame]  # Spell IDs (not display names)
       - id: subrace_languages
         title: Extra Language
         type: LANGUAGE
         choose: 1
         options: []
+    # Starlight Step: Teleportation ability (functions like Misty Step but isn't a spell)
+    # Uses scale with proficiency bonus (2/3/4/5/6 at levels 1/5/9/13/17)
+    innate_spells:
+      - spell_id: misty_step
+        level_requirement: 1
+        spell_level: 2
+        uses: proficiency_bonus  # Scales with character level
+        recovery: long_rest
+        casting_ability: intelligence  # Not actually used since it's not a spell attack/save
+        description: "Starlight Step: As a bonus action, magically teleport up to 30 feet to an unoccupied space you can see. You can use this trait a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."

--- a/DMContent/Races/giff.yml
+++ b/DMContent/Races/giff.yml
@@ -1,4 +1,6 @@
 name: Giff
+creature_type: Humanoid
+source_url: "https://www.dndbeyond.com/races/giff"
 description: Giff are bipedal hippopotamus-like folk with a passion for explosives, military structure, and strength. They are known for their brute power and discipline, often serving in astral navies.
 ability_scores:
   choice:
@@ -7,16 +9,36 @@ ability_scores:
       - [1, 1, 1]
 size: Medium
 speed: 30
-swimming_speed: 30
-languages:
-  - Common
+
+# Display-only trait names
 traits:
   - Damage Dealer
   - Firearm Mastery
   - Hippo Build
+
+languages:
+  - Common
+
+# Player choices during character creation
 player_choices:
   - id: race_languages
     title: Languages
     type: LANGUAGE
     choose: 1
     options: []
+
+# Mechanical trait implementations
+# Hippo Build: Swimming speed equal to walking speed
+swimming_speed: 30
+
+# Damage Dealer: Advantage on STR checks/saves when pushing, pulling, lifting, or breaking objects
+# (Requires special handling in skill system - Issue #63)
+conditional_advantages:
+  - type: ability_check
+    ability: strength
+    condition: pushing_pulling_lifting_breaking
+    description: "You have advantage on Strength checks and saves when pushing, pulling, lifting, or breaking objects."
+
+# Firearm Mastery: Proficiency with firearms, no loading property penalty
+# (Requires firearm system - Issue #63)
+firearm_mastery: true

--- a/DMContent/Races/gnome.yml
+++ b/DMContent/Races/gnome.yml
@@ -7,12 +7,26 @@ ability_scores:
     Intelligence: 2
 size: Small
 speed: 25
+
+# Display-only trait names
 traits:
   - Darkvision
   - Gnome Cunning
+
 languages:
   - Common
   - Gnomish
+
+# Mechanical trait implementations
+darkvision: 60  # 60 ft. darkvision range
+
+# Gnome Cunning: Advantage on INT/WIS/CHA saves vs magic
+conditional_advantages:
+  - type: saving_throw
+    condition: magic
+    abilities: [intelligence, wisdom, charisma]
+    description: "You have advantage on Intelligence, Wisdom, and Charisma saving throws against magic."
+
 subraces:
   forest_gnome:
     name: Forest Gnome
@@ -23,6 +37,16 @@ subraces:
     traits:
       - Natural Illusionist
       - Speak with Small Beasts
+    # Natural Illusionist: Minor Illusion cantrip
+    innate_spells:
+      - spell_id: minor_illusion
+        level_requirement: 1
+        type: cantrip
+        casting_ability: intelligence
+        description: "You know the Minor Illusion cantrip."
+    # Speak with Small Beasts: Communicate simple ideas with Small or smaller beasts
+    # (Requires special handling - Issue #63)
+
   rock_gnome:
     name: Rock Gnome
     description: As a rock gnome, you have a natural inventiveness and hardiness beyond that of other gnomes.
@@ -32,6 +56,11 @@ subraces:
     traits:
       - Artificer's Lore
       - Tinker
+    # Artificer's Lore: Add double proficiency to History checks about magic items, alchemical objects, technological devices
+    # (Requires special handling - Issue #63)
+    # Tinker: Can craft tiny clockwork devices
+    # (Requires special crafting system - Issue #63)
+
   deep_gnome:
     name: Deep Gnome (Svirfneblin)
     description: Forest gnomes and rock gnomes are the gnomes most commonly encountered in the lands of the surface world. There is another subrace of gnomes rarely seen by any surface-dweller - deep gnomes, also known as svirfneblin.
@@ -41,3 +70,7 @@ subraces:
     traits:
       - Superior Darkvision
       - Stone Camouflage
+    # Superior Darkvision
+    darkvision: 120
+    # Stone Camouflage: Advantage on Stealth checks in rocky terrain
+    # (Requires terrain detection - Issue #63)

--- a/DMContent/Races/half_elf.yml
+++ b/DMContent/Races/half_elf.yml
@@ -10,16 +10,44 @@ ability_scores:
       - [1, 1]  # Choose two different abilities for +1 each
 size: Medium
 speed: 30
+
+# Display-only trait names
 traits:
   - Darkvision
   - Fey Ancestry
   - Skill Versatility
+
 languages:
   - Common
   - Elvish
+
+# Player choices during character creation
 player_choices:
   - id: race_languages
     title: Languages
     type: LANGUAGE
     choose: 1
     options: []  # Empty means "choose from all languages"
+  - id: skill_versatility
+    title: Skill Versatility
+    type: SKILL
+    choose: 2
+    options: []  # Empty means "choose from all skills"
+
+# Mechanical trait implementations
+darkvision: 60  # 60 ft. darkvision range
+
+# Fey Ancestry: Advantage on saves vs charmed, immune to magical sleep
+conditional_advantages:
+  - type: saving_throw
+    condition: charmed
+    description: "You have advantage on saving throws against being charmed."
+condition_immunities:
+  - type: sleep
+    magical_only: true
+    description: "Magic can't put you to sleep."
+
+# Half-Elf rest: 6 hours for long rest (between human 8 and elf 4)
+rest_requirements:
+  long_rest_hours: 6
+  description: "Half-elves need 6 hours for a long rest."

--- a/DMContent/Races/half_orc.yml
+++ b/DMContent/Races/half_orc.yml
@@ -8,11 +8,29 @@ ability_scores:
     Constitution: 1
 size: Medium
 speed: 30
+
+# Display-only trait names
 traits:
   - Darkvision
   - Menacing
   - Relentless Endurance
   - Savage Attacks
+
 languages:
   - Common
   - Orc
+
+# Mechanical trait implementations
+darkvision: 60  # 60 ft. darkvision range
+
+# Menacing: Proficiency in Intimidation
+skill_proficiencies:
+  - intimidation
+
+# Relentless Endurance: Drop to 1 HP instead of 0 once per long rest
+# (Requires special handling in combat system - Issue #63)
+relentless_endurance: true
+
+# Savage Attacks: Extra weapon damage die on critical hit
+# (Requires special handling in combat system - Issue #63)
+savage_attacks: true

--- a/DMContent/Races/halfling.yml
+++ b/DMContent/Races/halfling.yml
@@ -7,13 +7,27 @@ ability_scores:
     Dexterity: 2
 size: Small
 speed: 25
+
+# Display-only trait names
 traits:
   - Lucky
   - Brave
   - Halfling Nimbleness
+
 languages:
   - Common
   - Halfling
+
+# Mechanical trait implementations
+# Lucky: When you roll a 1 on attack/ability check/save, reroll and use new roll
+lucky: true
+
+# Brave: Advantage on saving throws against being frightened
+conditional_advantages:
+  - type: saving_throw
+    condition: frightened
+    description: "You have advantage on saving throws against being frightened."
+
 subraces:
   lightfoot:
     name: Lightfoot Halfling
@@ -23,6 +37,9 @@ subraces:
         Charisma: 1
     traits:
       - Naturally Stealthy
+    # Naturally Stealthy: Can hide when obscured by creature >= 1 size larger
+    # (Special stealth rule, no direct mechanical field needed)
+
   stout:
     name: Stout Halfling
     description: As a stout halfling, you're hardier than average and have some resistance to poison.
@@ -31,6 +48,14 @@ subraces:
         Constitution: 1
     traits:
       - Stout Resilience
+    # Stout Resilience: Advantage on saves vs poison + resistance to poison damage
+    damage_resistances:
+      - poison
+    conditional_advantages:
+      - type: saving_throw
+        condition: poison
+        description: "You have advantage on saving throws against poison."
+
   ghostwise:
     name: Ghostwise Halfling
     description: Ghostwise halflings trace their ancestry back to a war among halfling tribes that sent their ancestors into flight from their homeland.
@@ -39,3 +64,5 @@ subraces:
         Wisdom: 1
     traits:
       - Silent Speech
+    # Silent Speech: Telepathic communication up to 30 ft
+    # (Would need special handling in chat/communication system)

--- a/DMContent/Races/human.yml
+++ b/DMContent/Races/human.yml
@@ -3,15 +3,24 @@ creature_type: Humanoid
 source_url: "https://dnd5e.fandom.com/wiki/Human"
 description: Humans are the most adaptable and ambitious people among the common races. Whatever drives them, humans are the innovators, the achievers, and the pioneers of the worlds.
 ability_scores:
-  choice:
-    distributions:
-      - [1, 1, 1, 1, 1, 1]  # Standard Human: +1 to all six abilities
+  fixed:
+    Strength: 1
+    Dexterity: 1
+    Constitution: 1
+    Intelligence: 1
+    Wisdom: 1
+    Charisma: 1
 size: Medium
 speed: 30
+
+# Display-only trait names
 traits:
   - Extra Language
+
 languages:
   - Common
+
+# Player choices during character creation
 player_choices:
   - id: race_languages
     title: Languages

--- a/DMContent/Races/plasmoid.yml
+++ b/DMContent/Races/plasmoid.yml
@@ -1,5 +1,6 @@
 name: Plasmoid
 creature_type: Ooze
+source_url: "https://www.dndbeyond.com/races/plasmoid"
 description: Plasmoids are amorphous oozelike beings with the ability to change their shape and appearance at will. They can compress and squeeze through small spaces, and communicate via pseudopods and imitation.
 ability_scores:
   choice:
@@ -8,14 +9,19 @@ ability_scores:
       - [1, 1, 1]
 #size: Medium  # Default - will be overridden by player choice
 speed: 30
-languages:
-  - Common
+
+# Display-only trait names
 traits:
   - Amorphous
   - Darkvision
   - Hold Breath
   - Natural Resilience
   - Shape Self
+
+languages:
+  - Common
+
+# Player choices during character creation
 player_choices:
   - id: race_size
     title: Size
@@ -27,3 +33,26 @@ player_choices:
     type: LANGUAGE
     choose: 1
     options: []
+
+# Mechanical trait implementations
+darkvision: 60  # 60 ft. darkvision range
+
+# Hold Breath: Can hold breath for 1 hour
+hold_breath_minutes: 60
+
+# Amorphous: Can squeeze through 1-inch-wide space, advantage on grapple checks/saves
+# (Requires special handling - Issue #63)
+amorphous: true
+
+# Natural Resilience: Resistance to acid and poison damage, advantage on poison saves
+damage_resistances:
+  - acid
+  - poison
+conditional_advantages:
+  - type: saving_throw
+    condition: poison
+    description: "You have advantage on saving throws against poison."
+
+# Shape Self: Can reshape body, change appearance as action
+# (Requires special handling - Issue #63)
+shape_self: true

--- a/DMContent/Races/tiefling.yml
+++ b/DMContent/Races/tiefling.yml
@@ -8,10 +8,42 @@ ability_scores:
     Intelligence: 1
 size: Medium
 speed: 30
+
+# Display-only trait names
 traits:
   - Darkvision
   - Hellish Resistance
   - Infernal Legacy
+
 languages:
   - Common
   - Infernal
+
+# Mechanical trait implementations
+darkvision: 60  # 60 ft. darkvision range
+
+# Fixed damage resistance
+damage_resistances:
+  - fire
+
+# Innate spellcasting (Infernal Legacy)
+innate_spells:
+  - spell_id: thaumaturgy
+    level_requirement: 1  # Available at character level 1
+    type: cantrip
+    casting_ability: charisma
+    description: "You know the Thaumaturgy cantrip."
+  - spell_id: hellish_rebuke
+    level_requirement: 3  # Available at character level 3
+    spell_level: 1
+    uses: 1
+    recovery: long_rest
+    casting_ability: charisma
+    description: "Once you reach 3rd level, you can cast Hellish Rebuke as a 2nd-level spell once per long rest."
+  - spell_id: darkness
+    level_requirement: 5  # Available at character level 5
+    spell_level: 2
+    uses: 1
+    recovery: long_rest
+    casting_ability: charisma
+    description: "Once you reach 5th level, you can cast Darkness once per long rest."

--- a/src/main/java/io/papermc/jkvttplugin/character/CharacterCreationService.java
+++ b/src/main/java/io/papermc/jkvttplugin/character/CharacterCreationService.java
@@ -56,12 +56,12 @@ public class CharacterCreationService {
             System.out.println("After subrace contribution: " + pending.size());
         }
         if (dndClass != null) {
-            System.out.println("Class player choices: " + dndClass.getPlayerChoices().size());
+//            System.out.println("Class player choices: " + dndClass.getPlayerChoices().size());
             dndClass.contributeChoices(pending);
             System.out.println("After class contribution: " + pending.size());
         }
         if (background != null) {
-            System.out.println("Background player choices: " + background.getPlayerChoices().size());
+//            System.out.println("Background player choices: " + background.getPlayerChoices().size());
             background.contributeChoices(pending);
             System.out.println("After background contribution: " + pending.size());
         }

--- a/src/main/java/io/papermc/jkvttplugin/character/CharacterCreationSession.java
+++ b/src/main/java/io/papermc/jkvttplugin/character/CharacterCreationSession.java
@@ -87,6 +87,14 @@ public class CharacterCreationSession {
         this.selectedSpells = new LinkedHashSet<>(spells);
     }
 
+    public void addSelectedCantrip(String cantripName) {
+        this.selectedCantrips.add(cantripName);
+    }
+
+    public void addSelectedSpell(String spellName) {
+        this.selectedSpells.add(spellName);
+    }
+
     public Map<Integer, Set<String>> getSpellsByLevel() {
         Map<Integer, Set<String>> result = new HashMap<>();
         spellsByLevel.forEach((k, v) -> result.put(k, new LinkedHashSet<>(v)));

--- a/src/main/java/io/papermc/jkvttplugin/data/DataManager.java
+++ b/src/main/java/io/papermc/jkvttplugin/data/DataManager.java
@@ -22,20 +22,20 @@ public class DataManager {
         // Clear existing data before reloading (for /reloadyaml command)
         clearAllData();
 
-        File racesFolder = new File(dmContentFolder, "Races");
-        File classFolder = new File(dmContentFolder, "Classes");
-        File backgroundsFolder = new File(dmContentFolder, "Backgrounds");
         File spellFolder = new File(dmContentFolder, "Spells");
         File weaponFolder = new File(dmContentFolder, "Weapons");
         File armorFolder = new File(dmContentFolder, "Armor");
+        File racesFolder = new File(dmContentFolder, "Races");
+        File classFolder = new File(dmContentFolder, "Classes");
+        File backgroundsFolder = new File(dmContentFolder, "Backgrounds");
         File itemFolder = new File(dmContentFolder, "Items");
-        RaceLoader.loadAllRaces(racesFolder);
-        ClassLoader.loadAllClasses(classFolder);
-        BackgroundLoader.loadAllBackgrounds(backgroundsFolder);
         SpellLoader.loadAllSpells(spellFolder);
         WeaponLoader.loadAllWeapons(weaponFolder);
         ArmorLoader.loadAllArmors(armorFolder);
         ItemLoader.loadAllItems(itemFolder);
+        RaceLoader.loadAllRaces(racesFolder);
+        ClassLoader.loadAllClasses(classFolder);
+        BackgroundLoader.loadAllBackgrounds(backgroundsFolder);
     }
 
     /**

--- a/src/main/java/io/papermc/jkvttplugin/data/loader/RaceLoader.java
+++ b/src/main/java/io/papermc/jkvttplugin/data/loader/RaceLoader.java
@@ -57,7 +57,19 @@ public class RaceLoader {
                 .languages(langResult.languages)
                 .subraces(LoaderUtils.parseSubraces(data.get("subraces")))
                 .playerChoices(LoaderUtils.parsePlayerChoices(data.get("player_choices")))
-                .icon((String) data.getOrDefault("icon_name", null));
+                .icon((String) data.getOrDefault("icon_name", null))
+            // Parse new mechanical trait fields (Issue #51)
+                .swimmingSpeed((int) data.getOrDefault("swimming_speed", 0))
+                .flyingSpeed((int) data.getOrDefault("flying_speed", 0))
+                .climbingSpeed((int) data.getOrDefault("climbing_speed", 0))
+                .burrowingSpeed((int) data.getOrDefault("burrowing_speed", 0))
+                .darkvision((Integer) data.get("darkvision"))
+                .damageResistances(LoaderUtils.parseStringList(data.get("damage_resistances")))
+                .skillProficiencies(LoaderUtils.parseStringList(data.get("skill_proficiencies")))
+                .weaponProficiencies(LoaderUtils.parseStringList(data.get("weapon_proficiencies")))
+                .armorProficiencies(LoaderUtils.parseStringList(data.get("armor_proficiencies")))
+                .innateSpells(LoaderUtils.parseInnateSpells(data.get("innate_spells")));
+
 
         DndRace dndRace = builder.build();
         return dndRace;

--- a/src/main/java/io/papermc/jkvttplugin/data/loader/SpellLoader.java
+++ b/src/main/java/io/papermc/jkvttplugin/data/loader/SpellLoader.java
@@ -44,6 +44,7 @@ public class SpellLoader {
 
                     try {
                         DndSpell spell = parseSpell(spellKey, spellData);
+                        spell.setId(spellKey.toLowerCase());  // Set the spell ID
                         spells.put(spellKey.toLowerCase(), spell);
                         LOGGER.info("Loaded spell: " + spell.getName());
                     } catch (Exception e) {

--- a/src/main/java/io/papermc/jkvttplugin/data/model/ChoiceCategory.java
+++ b/src/main/java/io/papermc/jkvttplugin/data/model/ChoiceCategory.java
@@ -11,6 +11,7 @@ public enum ChoiceCategory {
     SKILL("Skills", Material.IRON_SWORD),
     TOOL("Tools", Material.IRON_PICKAXE),
     EQUIPMENT("Equipment", Material.CHEST),
+    SPELL("Spell", Material.BONE_MEAL),
     EXTRA("Other", Material.PAPER); // Size, feats, and other miscellaneous choices
 
     private final String displayName;
@@ -42,6 +43,7 @@ public enum ChoiceCategory {
             case SKILL -> SKILL;
             case TOOL -> TOOL;
             case EQUIPMENT -> EQUIPMENT;
+            case SPELL -> SPELL;
             case CUSTOM -> categorizeCustom(choiceId);
             case FEAT, ABILITY_SCORE -> EXTRA;
         };

--- a/src/main/java/io/papermc/jkvttplugin/data/model/DndSpell.java
+++ b/src/main/java/io/papermc/jkvttplugin/data/model/DndSpell.java
@@ -11,7 +11,8 @@ import org.bukkit.inventory.ItemStack;
 import java.util.List;
 
 public class DndSpell {
-    private String name;
+    private String id;           // The spell ID (e.g., "chill_touch")
+    private String name;         // The display name (e.g., "Chill Touch")
     private int level;
     private SpellSchool school;
     private List<String> classes;
@@ -29,6 +30,13 @@ public class DndSpell {
     private String damageType;
 
     public DndSpell() {}
+
+    public String getId() {
+        return id;
+    }
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public String getName() {
         return name;

--- a/src/main/java/io/papermc/jkvttplugin/data/model/DndSubRace.java
+++ b/src/main/java/io/papermc/jkvttplugin/data/model/DndSubRace.java
@@ -1,20 +1,17 @@
 package io.papermc.jkvttplugin.data.model;
 
 import io.papermc.jkvttplugin.data.model.enums.Ability;
-import io.papermc.jkvttplugin.data.model.enums.LanguageRegistry;
 import io.papermc.jkvttplugin.util.ChoiceUtil;
 import io.papermc.jkvttplugin.util.LoreBuilder;
 import io.papermc.jkvttplugin.util.Util;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class DndSubRace {
@@ -29,6 +26,20 @@ public class DndSubRace {
     private List<String> languages;
     private List<ChoiceEntry> playerChoices = List.of();
     private String icon;
+
+    // Mechanical trait implementations (Issue #51)
+    // Subraces can override or extend base race traits
+    private int speed;           // Override base race speed (e.g., Wood Elf 35 vs Elf 30), 0 = use parent race speed
+    private int swimmingSpeed;   // Override/add swimming speed, 0 = use parent race speed or default
+    private int flyingSpeed;     // Override/add flying speed, 0 = use parent race speed or can't fly
+    private int climbingSpeed;   // Override/add climbing speed, 0 = use parent race speed or default
+    private int burrowingSpeed;  // Override/add burrowing speed, 0 = use parent race speed or can't burrow
+    private Integer darkvision;  // Override base race darkvision (e.g., Drow 120 vs Elf 60)
+    private List<String> damageResistances = List.of();
+    private List<String> skillProficiencies = List.of();
+    private List<String> weaponProficiencies = List.of();
+    private List<String> armorProficiencies = List.of();
+    private List<InnateSpell> innateSpells = List.of();
 
     public DndSubRace() {}
 
@@ -81,6 +92,83 @@ public class DndSubRace {
         this.languages = languages != null ? List.copyOf(languages) : List.of();
     }
 
+    public int getSpeed() {
+        return speed;
+    }
+    public void setSpeed(int speed) {
+        this.speed = speed;
+    }
+
+    public int getSwimmingSpeed() {
+        return swimmingSpeed;
+    }
+    public void setSwimmingSpeed(int swimmingSpeed) {
+        this.swimmingSpeed = swimmingSpeed;
+    }
+
+    public int getFlyingSpeed() {
+        return flyingSpeed;
+    }
+    public void setFlyingSpeed(int flyingSpeed) {
+        this.flyingSpeed = flyingSpeed;
+    }
+
+    public int getClimbingSpeed() {
+        return climbingSpeed;
+    }
+    public void setClimbingSpeed(int climbingSpeed) {
+        this.climbingSpeed = climbingSpeed;
+    }
+
+    public int getBurrowingSpeed() {
+        return burrowingSpeed;
+    }
+    public void setBurrowingSpeed(int burrowingSpeed) {
+        this.burrowingSpeed = burrowingSpeed;
+    }
+
+    public Integer getDarkvision() {
+        return darkvision;
+    }
+    public void setDarkvision(Integer darkvision) {
+        this.darkvision = darkvision;
+    }
+
+    public List<String> getDamageResistances() {
+        return damageResistances;
+    }
+    public void setDamageResistances(List<String> damageResistances) {
+        this.damageResistances = damageResistances != null ? List.copyOf(damageResistances) : List.of();
+    }
+
+    public List<String> getSkillProficiencies() {
+        return skillProficiencies;
+    }
+    public void setSkillProficiencies(List<String> skillProficiencies) {
+        this.skillProficiencies = skillProficiencies != null ? List.copyOf(skillProficiencies) : List.of();
+    }
+
+    public List<String> getWeaponProficiencies() {
+        return weaponProficiencies;
+    }
+    public void setWeaponProficiencies(List<String> weaponProficiencies) {
+        this.weaponProficiencies = weaponProficiencies != null ? List.copyOf(weaponProficiencies) : List.of();
+    }
+
+    public List<String> getArmorProficiencies() {
+        return armorProficiencies;
+    }
+    public void setArmorProficiencies(List<String> armorProficiencies) {
+        this.armorProficiencies = armorProficiencies != null ? List.copyOf(armorProficiencies) : List.of();
+    }
+
+    public List<InnateSpell> getInnateSpells() {
+        return innateSpells;
+    }
+    public void setInnateSpells(List<InnateSpell> innateSpells) {
+        this.innateSpells = innateSpells != null ? List.copyOf(innateSpells) : List.of();
+    }
+
     public void setPlayerChoices(List<ChoiceEntry> playerChoices) {
         this.playerChoices = playerChoices == null ? List.of() : List.copyOf(playerChoices);
     }
@@ -100,25 +188,9 @@ public class DndSubRace {
 
     public void contributeChoices(List<PendingChoice<?>> out) {
         for(ChoiceEntry e : playerChoices) {
-            switch (e.type()) {
-                case LANGUAGE -> {
-                    PlayersChoice<String> pc = (PlayersChoice<String>) e.pc();
-                    boolean emptyOptions = (pc.getOptions() == null || pc.getOptions().isEmpty());
-                    if (emptyOptions) {
-                        List<String> allLangs = LanguageRegistry.getAllLanguages();
-                        pc = new PlayersChoice<>(pc.getChoose(), allLangs, PlayersChoice.ChoiceType.LANGUAGE);
-                    }
-                    if (ChoiceUtil.usable(pc)) {
-                        out.add(PendingChoice.ofStrings(e.id(), e.title(), pc, "race"));
-                    }
-                }
-                case CUSTOM -> {
-                    PlayersChoice<String> pc = (PlayersChoice<String>) e.pc();
-                    if (ChoiceUtil.usable(pc)) {
-                        out.add(PendingChoice.ofStrings(e.id(), e.title(), pc, "race"));
-                    }
-                }
-                default -> {}
+            PlayersChoice<String> pc = (PlayersChoice<String>) e.pc();
+            if (ChoiceUtil.usable(pc)) {
+                out.add(PendingChoice.ofStrings(e.id(), e.title(), pc, "race"));
             }
         }
     }
@@ -211,6 +283,61 @@ public class DndSubRace {
 
         public Builder icon(String icon) {
             instance.setIcon(icon);
+            return this;
+        }
+
+        public Builder speed(int speed) {
+            instance.setSpeed(speed);
+            return this;
+        }
+
+        public Builder swimmingSpeed(int swimmingSpeed) {
+            instance.setSwimmingSpeed(swimmingSpeed);
+            return this;
+        }
+
+        public Builder flyingSpeed(int flyingSpeed) {
+            instance.setFlyingSpeed(flyingSpeed);
+            return this;
+        }
+
+        public Builder climbingSpeed(int climbingSpeed) {
+            instance.setClimbingSpeed(climbingSpeed);
+            return this;
+        }
+
+        public Builder burrowingSpeed(int burrowingSpeed) {
+            instance.setBurrowingSpeed(burrowingSpeed);
+            return this;
+        }
+
+        public Builder darkvision(Integer darkvision) {
+            instance.setDarkvision(darkvision);
+            return this;
+        }
+
+        public Builder damageResistances(List<String> damageResistances) {
+            instance.setDamageResistances(damageResistances);
+            return this;
+        }
+
+        public Builder skillProficiencies(List<String> skillProficiencies) {
+            instance.setSkillProficiencies(skillProficiencies);
+            return this;
+        }
+
+        public Builder weaponProficiencies(List<String> weaponProficiencies) {
+            instance.setWeaponProficiencies(weaponProficiencies);
+            return this;
+        }
+
+        public Builder armorProficiencies(List<String> armorProficiencies) {
+            instance.setArmorProficiencies(armorProficiencies);
+            return this;
+        }
+
+        public Builder innateSpells(List<InnateSpell> innateSpells) {
+            instance.setInnateSpells(innateSpells);
             return this;
         }
 

--- a/src/main/java/io/papermc/jkvttplugin/data/model/InnateSpell.java
+++ b/src/main/java/io/papermc/jkvttplugin/data/model/InnateSpell.java
@@ -1,0 +1,205 @@
+package io.papermc.jkvttplugin.data.model;
+
+import io.papermc.jkvttplugin.data.model.enums.Ability;
+
+/**
+ * Represents a racial innate spell (e.g., Tiefling's Hellish Rebuke, Drow's Faerie Fire).
+ * Innate spells can be cantrips (unlimited use) or leveled spells (limited uses per rest).
+ */
+public class InnateSpell {
+    private String spellId;           // References spell in spell registry
+    private int levelRequirement;     // Character level when spell becomes available (1, 3, 5, etc.)
+    private boolean isCantrip;        // True for cantrips, false for leveled spells
+    private int spellLevel;           // Spell level (1-9) for leveled spells, 0 for cantrips
+    private int uses;                 // Uses per rest (0 for cantrips = unlimited, -1 if scales with proficiency)
+    private int usesRemaining;        // Current remaining uses (runtime tracking, not from YAML)
+    private boolean scalesWithProficiency; // True if uses = proficiency bonus
+    private String recovery;          // "long_rest", "short_rest", "dawn", etc.
+    private Ability castingAbility;   // Intelligence, Wisdom, or Charisma
+    private String description;       // Optional description text
+
+    public InnateSpell() {
+        // Initialize usesRemaining to match uses (full charges)
+        this.usesRemaining = this.uses;
+    }
+
+    public String getSpellId() {
+        return spellId;
+    }
+
+    public void setSpellId(String spellId) {
+        this.spellId = spellId;
+    }
+
+    public int getLevelRequirement() {
+        return levelRequirement;
+    }
+
+    public void setLevelRequirement(int levelRequirement) {
+        this.levelRequirement = levelRequirement;
+    }
+
+    public boolean isCantrip() {
+        return isCantrip;
+    }
+
+    public void setCantrip(boolean cantrip) {
+        isCantrip = cantrip;
+    }
+
+    public int getSpellLevel() {
+        return spellLevel;
+    }
+
+    public void setSpellLevel(int spellLevel) {
+        this.spellLevel = spellLevel;
+    }
+
+    public int getUses() {
+        return uses;
+    }
+
+    public void setUses(int uses) {
+        this.uses = uses;
+        // When setting max uses, also initialize remaining uses if not yet set
+        if (this.usesRemaining == 0 && uses > 0) {
+            this.usesRemaining = uses;
+        }
+    }
+
+    public int getUsesRemaining() {
+        return usesRemaining;
+    }
+
+    public void setUsesRemaining(int usesRemaining) {
+        this.usesRemaining = usesRemaining;
+    }
+
+    public boolean isScalesWithProficiency() {
+        return scalesWithProficiency;
+    }
+    public void setScalesWithProficiency(boolean scalesWithProficiency) {
+        this.scalesWithProficiency = scalesWithProficiency;
+    }
+
+    public String getRecovery() {
+        return recovery;
+    }
+
+    public void setRecovery(String recovery) {
+        this.recovery = recovery;
+    }
+
+    public Ability getCastingAbility() {
+        return castingAbility;
+    }
+
+    public void setCastingAbility(Ability castingAbility) {
+        this.castingAbility = castingAbility;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * Check if this innate spell is available at the given character level.
+     */
+    public boolean isAvailableAtLevel(int characterLevel) {
+        return characterLevel >= levelRequirement;
+    }
+
+    /**
+     * Checks if this spell can currently be cast.
+     * Cantrips can always be cast (unlimited uses). Limited-use abilities require remaining uses.
+     *
+     * @return true if the spell has uses remaining or is a cantrip, false otherwise
+     */
+    public boolean canCast() {
+        return isCantrip || usesRemaining > 0;
+    }
+
+    /**
+     * Uses this innate spell, consuming one charge.
+     * Cantrips are not affected (unlimited uses). Limited-use spells decrement remaining uses.
+     *
+     * @return true if successfully used, false if no uses remaining
+     */
+    public boolean use() {
+        if (isCantrip) return true; // Cantrips have unlimited uses
+        if (usesRemaining > 0) {
+            usesRemaining--;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Resets uses to maximum, typically called after a rest.
+     * For proficiency-scaling abilities (e.g., Astral Elf's Starlight Step),
+     * recalculates maximum uses based on current proficiency bonus.
+     * For fixed-use abilities, simply restores to predefined maximum.
+     *
+     * @param proficiencyBonus The character's current proficiency bonus (+2 at level 1-4, +3 at 5-8, etc.)
+     */
+    public void resetUses(int proficiencyBonus) {
+        if (scalesWithProficiency) {
+            this.uses = proficiencyBonus;
+            this.usesRemaining = proficiencyBonus;
+        } else {
+            this.usesRemaining = this.uses;
+        }
+    }
+
+    /**
+     * Initializes the uses for this innate spell, called when character is created or loaded.
+     * For proficiency-scaling abilities, calculates and sets both maximum and remaining uses
+     * based on the character's proficiency bonus. For fixed-use spells, ensures remaining
+     * uses are initialized to maximum if not already set.
+     *
+     * <p>This method should be called:
+     * <ul>
+     *   <li>During character creation (after racial traits are applied)</li>
+     *   <li>When loading a character from save file</li>
+     *   <li>After leveling up (when proficiency bonus changes)</li>
+     * </ul>
+     *
+     * @param proficiencyBonus The character's proficiency bonus (+2 at level 1-4, +3 at 5-8, etc.)
+     */
+    public void initializeUses(int proficiencyBonus) {
+        if (scalesWithProficiency) {
+            this.uses = proficiencyBonus;
+            this.usesRemaining = proficiencyBonus;
+        } else if (this.usesRemaining == 0 && this.uses > 0) {
+            this.usesRemaining = this.uses;
+        }
+    }
+
+    /**
+     * Gets a formatted string displaying current usage for UI tooltips.
+     *
+     * @return "At Will" for cantrips and unlimited-use abilities, or "X/Y" format for limited uses (e.g., "2/2", "0/1")
+     */
+    public String getUsageDisplay() {
+        if (isCantrip || uses == 0) {
+            return "At Will";
+        }
+        return usesRemaining + "/" + uses;
+    }
+
+    @Override
+    public String toString() {
+        return "InnateSpell{" +
+                "spellId='" + spellId + '\'' +
+                ", levelRequirement=" + levelRequirement +
+                ", isCantrip=" + isCantrip +
+                ", uses=" + uses +
+                ", recovery='" + recovery + '\'' +
+                ", castingAbility=" + castingAbility +
+                '}';
+    }
+}

--- a/src/main/java/io/papermc/jkvttplugin/data/model/PlayersChoice.java
+++ b/src/main/java/io/papermc/jkvttplugin/data/model/PlayersChoice.java
@@ -4,7 +4,7 @@ import java.util.*;
 
 public class PlayersChoice<T> {
     public enum ChoiceType {
-        SKILL, TOOL, LANGUAGE, EQUIPMENT, FEAT, ABILITY_SCORE, CUSTOM
+        SKILL, TOOL, LANGUAGE, EQUIPMENT, FEAT, ABILITY_SCORE, SPELL, CUSTOM
     }
 
     private final int choose;

--- a/src/main/java/io/papermc/jkvttplugin/util/ChoiceMerger.java
+++ b/src/main/java/io/papermc/jkvttplugin/util/ChoiceMerger.java
@@ -101,6 +101,7 @@ public class ChoiceMerger {
             case LANGUAGE -> KnownItemCollector.collectKnownLanguages(session);
             case SKILL -> KnownItemCollector.collectKnownSkills(session);
             case TOOL -> KnownItemCollector.collectKnownTools(session);
+            case SPELL -> KnownItemCollector.collectKnownSpells(session);
             case EQUIPMENT, EXTRA -> Collections.emptySet(); // No filtering needed
         };
     }

--- a/src/main/java/io/papermc/jkvttplugin/util/KnownItemCollector.java
+++ b/src/main/java/io/papermc/jkvttplugin/util/KnownItemCollector.java
@@ -30,17 +30,18 @@ public class KnownItemCollector {
 
         DndRace race = RaceLoader.getRace(session.getSelectedRace());
         if (race != null && race.getLanguages() != null) {
-            known.addAll(race.getLanguages());
+            // Normalize using Util.normalize() for consistent filtering
+            race.getLanguages().forEach(lang -> known.add(Util.normalize(lang)));
         }
 
         DndSubRace subrace = getSubrace(session);
         if (subrace != null && subrace.getLanguages() != null) {
-            known.addAll(subrace.getLanguages());
+            subrace.getLanguages().forEach(lang -> known.add(Util.normalize(lang)));
         }
 
         DndBackground bg = BackgroundLoader.getBackground(session.getSelectedBackground());
         if (bg != null && bg.getLanguages() != null) {
-            known.addAll(bg.getLanguages());
+            bg.getLanguages().forEach(lang -> known.add(Util.normalize(lang)));
         }
 
         return known;
@@ -87,6 +88,29 @@ public class KnownItemCollector {
         DndBackground bg = BackgroundLoader.getBackground(session.getSelectedBackground());
         if (bg != null && bg.getTools() != null) {
             known.addAll(bg.getTools());
+        }
+
+        return known;
+    }
+
+    /**
+     * Collects all spells the character already knows from their chosen spells and cantrips.
+     * Does not include fixed grants - only spells selected via player choices.
+     *
+     * @param session The character creation session
+     * @return Set of spell names the character knows
+     */
+    public static Set<String> collectKnownSpells(CharacterCreationSession session) {
+        Set<String> known = new LinkedHashSet<>();
+
+        // Add already-selected cantrips
+        if (session.getSelectedCantrips() != null) {
+            known.addAll(session.getSelectedCantrips());
+        }
+
+        // Add already-selected leveled spells
+        if (session.getSelectedSpells() != null) {
+            known.addAll(session.getSelectedSpells());
         }
 
         return known;


### PR DESCRIPTION
## Summary

This PR implements comprehensive support for racial innate spellcasting and abilities, allowing races like Tieflings, Drow, and Astral Elves to have limited-use magical abilities that function separately from class spellcasting.

## Features Implemented

### ✨ Innate Spell System
- **New `InnateSpell.java` model** with runtime usage tracking
- Separate tracking from spell slots (innate uses vs class spell slots)
- Recovery types: `long_rest`, `short_rest`, integrated with rest system
- Helper methods: `canCast()`, `use()`, `resetUses()`, `initializeUses()`, `getUsageDisplay()`

### 📊 Proficiency Bonus Scaling
- YAML support for `uses: proficiency_bonus` string format
- Dynamic use calculation (2→3→4→5→6 at character levels 1/5/9/13/17)
- Properly initializes on character creation and recalculates on level-up
- Example: Astral Elf's Starlight Step scales with proficiency

### 🎨 Spell Menu UI for Non-Spellcasters
- Characters with only racial cantrips can now access spell menu
- **Purple glass pane buttons** for spell levels with innate abilities but no spell slots
- **"✦ Racial Ability" marker** for visual distinction
- **Usage display** shows remaining charges (e.g., "Uses: 1/2")
- **"Innate Abilities Only"** tooltip for clarity

### ⚔️ Dual Spell System
- Innate spells tracked separately from class spells
- Different casting logic: checks `canCast()` instead of spell slots
- Proper concentration handling for both systems
- Different messages: "You use Hellish Rebuke! (0/1 remaining)" vs spell slot consumption

## Code Quality Improvements

### 📝 Documentation
- Added comprehensive JavaDoc to all new public methods
- Production-level documentation standards
- Clear parameter descriptions and usage examples

### 🔧 Refactoring
- Extracted `CharacterSheet.hasInnateSpellsAtLevel()` helper method (reduced lambda duplication)
- Extracted `SpellCastingMenuListener.handleConcentration()` helper method (eliminated 3x duplicate code)
- Removed verbose debug logging from `LoaderUtils.java` (kept warnings/errors only)

## Files Changed

### New Files
- `src/main/java/io/papermc/jkvttplugin/data/model/InnateSpell.java` - Core model for innate spells

### Modified Core Files
- `CharacterSheet.java` - Added innate spell getters, rest integration, helper methods
- `LoaderUtils.java` - Parser for innate_spells YAML, cleaned up logging
- `SpellCastingMenu.java` - Merged class and innate spells in UI
- `SpellCastingMenuListener.java` - Dual casting system with refactored concentration logic

### Modified Race Files (11 files)
- Updated all races with mechanical trait implementations
- Added `innate_spells` configurations for Tiefling, Drow, Pallid Elf, Astral Elf
- Fixed Astral Elf spell IDs and proficiency scaling
- Added darkvision, resistances, movement speeds, proficiencies to all races

## Testing Recommendations

### Test Case 1: Astral Elf Barbarian (Proficiency Scaling)
1. Create Astral Elf Barbarian, select Dancing Lights cantrip
2. Open spell menu - should see "Cantrips" button
3. Click 2nd level purple button for Misty Step (Starlight Step)
4. Cast 2 times, verify "0/2 remaining" message
5. Long rest, verify resets to "2/2"

### Test Case 2: Drow Character (Fixed Uses)
1. Create Drow character
2. Verify Dancing Lights cantrip (unlimited uses)
3. At level 3: Cast Faerie Fire once, verify "0/1 remaining"
4. At level 5: Cast Darkness once, verify "0/1 remaining"
5. Long rest, verify both reset to "1/1"

### Test Case 3: Tiefling Wizard (Dual Spell Scenario)
1. Create Tiefling Wizard with Hellish Rebuke as known spell
2. Open spell menu - should see Hellish Rebuke with "✦ Racial Ability" marker
3. Cast innate version (1/long rest)
4. Note: Currently always uses innate version first (see known limitation)

## Known Limitations

### Dual Spell Scenario (Issue #68)
Characters with the same spell as both innate AND class spell (e.g., Tiefling Cleric with Hellish Rebuke) currently always cast the innate version first. This prevents players from choosing to preserve limited racial uses and consume spell slots instead.

**Decision deferred** to Issue #68 for future UX consideration. Possible solutions:
- Option 1: Prioritize spell slots (inverse current behavior)
- Option 2: Show both versions separately in UI
- Option 3: Create separate "Racial Abilities" menu
- Option 4: Prompt player on cast (modal dialog)
- Option 5: Smart default with modifier key override (shift-click)

## Related Issues

- Closes #51 (Racial innate spellcasting and abilities)
- Creates #68 (Dual spell scenario - UX decision needed)

## Statistics

- **29 files changed**
- **1,673 insertions**
- **176 deletions**
- **Net +1,497 lines** (includes JavaDoc, new model, YAML data)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)